### PR TITLE
Add Docker Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3-slim
+
+WORKDIR /usr/src
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+VOLUME [ "/usr/src/app/config" ]
+COPY . .
+
+CMD [ "python", "./main.py" ]

--- a/main.py
+++ b/main.py
@@ -54,5 +54,5 @@ if __name__ == '__main__':
 
     # 启动
     # app.run(host="127.0.0.1", port=5000, debug=True, threaded=True, use_reloader=False)
-    http_server = WSGIServer(("127.0.0.1", 5000), app)
+    http_server = WSGIServer(("0.0.0.0", 5000), app)
     http_server.serve_forever()


### PR DESCRIPTION
## Commits
- Listening defaults to `0.0.0.0:5000` instead of `127.0.0.1:5000` for Docker networking.
- Add `Dockerfile`.

## Usage
1. Add config files (`switch.yml` etc.) into a directory (e.g. `/home/me/justlist-config/`).
2. Run `docker run -d -p 5000:5000 -v /home/me/justlist-config:/usr/src/app/config DOCKER_IMAGE_TAG_HERE`

## Notes
I have already pushed `hmqgg/justlist-docker` to Docker Hub based on my fork with Cloud189 login fix patch.
If you wanna build an official image, please let me know so I could pull down my own Docker Hub image.